### PR TITLE
fix: `mypy chatkit` errors

### DIFF
--- a/chatkit/actions.py
+++ b/chatkit/actions.py
@@ -23,7 +23,7 @@ TPayload = TypeVar("TPayload")
 
 
 class Action(BaseModel, Generic[TType, TPayload]):
-    type: TType = Field(default=TType, frozen=True)  # pyright: ignore
+    type: TType = Field(frozen=True)  # pyright: ignore
     payload: TPayload
 
     @classmethod

--- a/chatkit/server.py
+++ b/chatkit/server.py
@@ -323,7 +323,7 @@ class ChatKitServer(ABC, Generic[TContext]):
                 return self._serialize(self._to_thread_response(thread))
             case ThreadsListReq():
                 params = request.params
-                threads = await self.store.load_threads(
+                thread_meta_page = await self.store.load_threads(
                     limit=params.limit or DEFAULT_PAGE_SIZE,
                     after=params.after,
                     order=params.order,
@@ -331,10 +331,11 @@ class ChatKitServer(ABC, Generic[TContext]):
                 )
                 return self._serialize(
                     Page(
-                        has_more=threads.has_more,
-                        after=threads.after,
+                        has_more=thread_meta_page.has_more,
+                        after=thread_meta_page.after,
                         data=[
-                            self._to_thread_response(thread) for thread in threads.data
+                            self._to_thread_response(thread_meta)
+                            for thread_meta in thread_meta_page.data
                         ],
                     )
                 )
@@ -378,12 +379,12 @@ class ChatKitServer(ABC, Generic[TContext]):
                 ]
                 return self._serialize(items)
             case ThreadsUpdateReq():
-                thread = await self.store.load_thread(
+                thread_meta = await self.store.load_thread(
                     request.params.thread_id, context=context
                 )
-                thread.title = request.params.title
-                await self.store.save_thread(thread, context=context)
-                return self._serialize(self._to_thread_response(thread))
+                thread_meta.title = request.params.title
+                await self.store.save_thread(thread_meta, context=context)
+                return self._serialize(self._to_thread_response(thread_meta))
             case ThreadsDeleteReq():
                 await self.store.delete_thread(
                     request.params.thread_id, context=context
@@ -426,25 +427,25 @@ class ChatKitServer(ABC, Generic[TContext]):
                     yield event
 
             case ThreadsAddUserMessageReq():
-                thread = await self.store.load_thread(
+                thread_meta = await self.store.load_thread(
                     request.params.thread_id, context=context
                 )
                 user_message = await self._build_user_message_item(
-                    request.params.input, thread, context
+                    request.params.input, thread_meta, context
                 )
                 async for event in self._process_new_thread_item_respond(
-                    thread,
+                    thread_meta,
                     user_message,
                     context,
                 ):
                     yield event
 
             case ThreadsAddClientToolOutputReq():
-                thread = await self.store.load_thread(
+                thread_meta = await self.store.load_thread(
                     request.params.thread_id, context=context
                 )
                 items = await self.store.load_thread_items(
-                    thread.id, None, 1, "desc", context
+                    thread_meta.id, None, 1, "desc", context
                 )
                 tool_call = next(
                     (
@@ -457,29 +458,29 @@ class ChatKitServer(ABC, Generic[TContext]):
                 )
                 if not tool_call:
                     raise ValueError(
-                        f"Last thread item in {thread.id} was not a ClientToolCallItem"
+                        f"Last thread item in {thread_meta.id} was not a ClientToolCallItem"
                     )
 
                 tool_call.output = request.params.result
                 tool_call.status = "completed"
 
-                await self.store.save_item(thread.id, tool_call, context=context)
+                await self.store.save_item(thread_meta.id, tool_call, context=context)
 
                 # Safety against dangling pending tool calls if there are
                 # multiple in a row, which should be impossible, and
                 # integrations should ultimately filter out pending tool calls
                 # when creating input response messages.
-                await self._cleanup_pending_client_tool_call(thread, context)
+                await self._cleanup_pending_client_tool_call(thread_meta, context)
 
                 async for event in self._process_events(
-                    thread,
+                    thread_meta,
                     context,
-                    lambda: self.respond(thread, None, context),
+                    lambda: self.respond(thread_meta, None, context),
                 ):
                     yield event
 
             case ThreadsRetryAfterItemReq():
-                thread_metadata = await self.store.load_thread(
+                thread_meta = await self.store.load_thread(
                     request.params.thread_id, context=context
                 )
 
@@ -505,29 +506,29 @@ class ChatKitServer(ABC, Generic[TContext]):
                             request.params.thread_id, item.id, context=context
                         )
                     async for event in self._process_events(
-                        thread_metadata,
+                        thread_meta,
                         context,
                         lambda: self.respond(
-                            thread_metadata,
+                            thread_meta,
                             user_message_item,
                             context,
                         ),
                     ):
                         yield event
             case ThreadsCustomActionReq():
-                thread_metadata = await self.store.load_thread(
+                thread_meta = await self.store.load_thread(
                     request.params.thread_id, context=context
                 )
 
-                item: ThreadItem | None = None
+                sender: ThreadItem | None = None
                 if request.params.item_id:
-                    item = await self.store.load_item(
+                    sender = await self.store.load_item(
                         request.params.thread_id,
                         request.params.item_id,
                         context=context,
                     )
 
-                if item and not isinstance(item, WidgetItem):
+                if sender and not isinstance(sender, WidgetItem):
                     # shouldn't happen if the caller is using the API correctly.
                     yield ErrorEvent(
                         code=ErrorCode.STREAM_ERROR,
@@ -536,12 +537,12 @@ class ChatKitServer(ABC, Generic[TContext]):
                     return
 
                 async for event in self._process_events(
-                    thread_metadata,
+                    thread_meta,
                     context,
                     lambda: self.action(
-                        thread_metadata,
+                        thread_meta,
                         request.params.action,
-                        item,
+                        sender if isinstance(sender, WidgetItem) else None,
                         context,
                     ),
                 ):


### PR DESCRIPTION
before: 

```
(openai-chatkit) ➜  chatkit-python git:(main) mypy chatkit
chatkit/actions.py:26: error: "TType" is a type variable and only valid in type context  [misc]
chatkit/server.py:381: error: Incompatible types in assignment (expression has type "ThreadMetadata", variable has type "Thread")  [assignment]
chatkit/server.py:429: error: Incompatible types in assignment (expression has type "ThreadMetadata", variable has type "Thread")  [assignment]
chatkit/server.py:443: error: Incompatible types in assignment (expression has type "ThreadMetadata", variable has type "Thread")  [assignment]
chatkit/server.py:522: error: Name "item" already defined on line 490  [no-redef]
chatkit/server.py:544: error: Argument 3 to "action" of "ChatKitServer" has incompatible type "UserMessageItem | AssistantMessageItem | ClientToolCallItem | WidgetItem | WorkflowItem | TaskItem | HiddenContextItem | EndOfTurnItem"; expected "WidgetItem | None"  [arg-type]
chatkit/agents.py:389: error: Incompatible types in assignment (expression has type "ThreadCreatedEvent | ThreadUpdatedEvent | ThreadItemDoneEvent | ThreadItemAddedEvent | ThreadItemUpdated | ThreadItemRemovedEvent | ThreadItemReplacedEvent | ProgressUpdateEvent | ErrorEvent | NoticeEvent", variable has type "RawResponsesStreamEvent | RunItemStreamEvent | AgentUpdatedStreamEvent | _EventWrapper")  [assignment]
chatkit/agents.py:389: note: Items in the first union not in the second: "ThreadCreatedEvent", "ThreadUpdatedEvent", "ThreadItemDoneEvent", "ThreadItemAddedEvent", "ThreadItemUpdated", "ThreadItemRemovedEvent", "ThreadItemReplacedEvent", "ProgressUpdateEvent", "ErrorEvent", "NoticeEvent"
chatkit/agents.py:391: error: "_EventWrapper" has no attribute "type"  [attr-defined]
chatkit/agents.py:392: error: "_EventWrapper" has no attribute "type"  [attr-defined]
chatkit/agents.py:397: error: "_EventWrapper" has no attribute "item"  [attr-defined]
chatkit/agents.py:398: error: "_EventWrapper" has no attribute "item"  [attr-defined]
chatkit/agents.py:399: error: "_EventWrapper" has no attribute "item"  [attr-defined]
chatkit/agents.py:405: error: "_EventWrapper" has no attribute "type"  [attr-defined]
chatkit/agents.py:406: error: "_EventWrapper" has no attribute "item"  [attr-defined]
chatkit/agents.py:408: error: "_EventWrapper" has no attribute "item"  [attr-defined]
chatkit/agents.py:412: error: "_EventWrapper" has no attribute "item"  [attr-defined]
chatkit/agents.py:413: error: Incompatible types in "yield" (actual type "_EventWrapper", expected type "ThreadCreatedEvent | ThreadUpdatedEvent | ThreadItemDoneEvent | ThreadItemAddedEvent | ThreadItemUpdated | ThreadItemRemovedEvent | ThreadItemReplacedEvent | ProgressUpdateEvent | ErrorEvent | NoticeEvent")  [misc]
chatkit/agents.py:417: error: Incompatible types in assignment (expression has type "MessageOutputItem | HandoffCallItem | HandoffOutputItem | ToolCallItem | ToolCallOutputItem | ReasoningItem | MCPListToolsItem | MCPApprovalRequestItem | MCPApprovalResponseItem", variable has type "RawResponsesStreamEvent | RunItemStreamEvent | AgentUpdatedStreamEvent | _EventWrapper")  [assignment]
chatkit/agents.py:433: error: Incompatible types in assignment (expression has type "ResponseAudioDeltaEvent | ResponseAudioDoneEvent | ResponseAudioTranscriptDeltaEvent | ResponseAudioTranscriptDoneEvent | ResponseCodeInterpreterCallCodeDeltaEvent | <48 more items>", variable has type "RawResponsesStreamEvent | RunItemStreamEvent | AgentUpdatedStreamEvent | _EventWrapper")  [assignment]
chatkit/agents.py:433: note: Items in the first union not in the second: "ResponseAudioDeltaEvent", "ResponseAudioDoneEvent", "ResponseAudioTranscriptDeltaEvent", "ResponseAudioTranscriptDoneEvent", "ResponseCodeInterpreterCallCodeDeltaEvent", "ResponseCodeInterpreterCallCodeDoneEvent", "ResponseCodeInterpreterCallCompletedEvent", "ResponseCodeInterpreterCallInProgressEvent", "ResponseCodeInterpreterCallInterpretingEvent", "ResponseCompletedEvent", "ResponseContentPartAddedEvent", "ResponseContentPartDoneEvent", "ResponseCreatedEvent", "ResponseErrorEvent", "ResponseFileSearchCallCompletedEvent", "ResponseFileSearchCallInProgressEvent", "ResponseFileSearchCallSearchingEvent", "ResponseFunctionCallArgumentsDeltaEvent", "ResponseFunctionCallArgumentsDoneEvent", "ResponseInProgressEvent", "ResponseFailedEvent", "ResponseIncompleteEvent", "ResponseOutputItemAddedEvent", "ResponseOutputItemDoneEvent", "ResponseReasoningSummaryPartAddedEvent", "ResponseReasoningSummaryPartDoneEvent", "ResponseReasoningSummaryTextDeltaEvent", "ResponseReasoningSummaryTextDoneEvent", "ResponseReasoningTextDeltaEvent", "ResponseReasoningTextDoneEvent", "ResponseRefusalDeltaEvent", "ResponseRefusalDoneEvent", "ResponseTextDeltaEvent", "ResponseTextDoneEvent", "ResponseWebSearchCallCompletedEvent", "ResponseWebSearchCallInProgressEvent", "ResponseWebSearchCallSearchingEvent", "ResponseImageGenCallCompletedEvent", "ResponseImageGenCallGeneratingEvent", "ResponseImageGenCallInProgressEvent", "ResponseImageGenCallPartialImageEvent", "ResponseMcpCallArgumentsDeltaEvent", "ResponseMcpCallArgumentsDoneEvent", "ResponseMcpCallCompletedEvent", "ResponseMcpCallFailedEvent", "ResponseMcpCallInProgressEvent", "ResponseMcpListToolsCompletedEvent", "ResponseMcpListToolsFailedEvent", "ResponseMcpListToolsInProgressEvent", "ResponseOutputTextAnnotationAddedEvent", "ResponseQueuedEvent", "ResponseCustomToolCallInputDeltaEvent", "ResponseCustomToolCallInputDoneEvent"
chatkit/agents.py:624: error: Incompatible types in "yield" (actual type "Markdown | Text", expected type "TWidget")  [misc]
chatkit/agents.py:625: error: Incompatible types in "yield" (actual type "Markdown | Text", expected type "TWidget")  [misc]
chatkit/agents.py:722: error: Incompatible return value type (got "list[Message]", expected "EasyInputMessageParam | Message | ResponseOutputMessageParam | ResponseFileSearchToolCallParam | ResponseComputerToolCallParam | <16 more items> | list[EasyInputMessageParam | Message | ResponseOutputMessageParam | ResponseFileSearchToolCallParam | ResponseComputerToolCallParam | <16 more items>] | None")  [return-value]
Found 22 errors in 3 files (checked 10 source files)
```

after:

```
(openai-chatkit) ➜  chatkit-python git:(qb/mypy) mypy chatkit
Success: no issues found in 10 source files
```