### PR TITLE
fix: correct widgets.md URL to point to openai/chatkit-python

### DIFF
--- a/chatkit/server.py
+++ b/chatkit/server.py
@@ -306,7 +306,7 @@ class ChatKitServer(ABC, Generic[TContext]):
     ) -> AsyncIterator[ThreadStreamEvent]:
         raise NotImplementedError(
             "The action() method must be overridden to react to actions. "
-            "See https://github.com/OpenAI-Early-Access/chatkit/blob/main/docs/widgets.md#widget-actions"
+            "See https://github.com/openai/chatkit-python/blob/main/docs/widgets.md#widget-actions"
         )
 
     async def process(


### PR DESCRIPTION
This PR fixes a broken documentation link in the code comments.

The previous URL pointed to the deprecated repository
https://github.com/OpenAI-Early-Access/chatkit, which not for public (404 error)