### PR TITLE
fix: Add compatibility module for StrEnum and assert_never (#12)

### DIFF
--- a/chatkit/_compat.py
+++ b/chatkit/_compat.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+try:
+    from enum import StrEnum
+except ImportError:  # Python < 3.11
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Minimal StrEnum compatibility for Python < 3.11."""
+
+
+try:
+    from typing import assert_never
+except ImportError:  # Python < 3.11
+    from typing import NoReturn
+
+    def assert_never(arg: NoReturn) -> NoReturn:
+        raise AssertionError(f"Expected code path to be unreachable, got: {arg!r}")
+
+
+__all__ = ("StrEnum", "assert_never")

--- a/chatkit/agents.py
+++ b/chatkit/agents.py
@@ -10,7 +10,6 @@ from typing import (
     Generic,
     Sequence,
     TypeVar,
-    assert_never,
     cast,
 )
 
@@ -39,6 +38,7 @@ from openai.types.responses.response_output_text import (
 )
 from pydantic import BaseModel, ConfigDict, SkipValidation, TypeAdapter
 
+from ._compat import assert_never
 from .server import stream_widget
 from .store import Store, StoreItemType
 from .types import (

--- a/chatkit/errors.py
+++ b/chatkit/errors.py
@@ -1,5 +1,6 @@
 from abc import ABC
-from enum import StrEnum
+
+from ._compat import StrEnum
 
 
 # Not a closed enum, new error codes can and will be added as needed

--- a/chatkit/server.py
+++ b/chatkit/server.py
@@ -3,14 +3,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from contextlib import contextmanager
 from datetime import datetime
-from typing import (
-    Any,
-    AsyncGenerator,
-    AsyncIterable,
-    Callable,
-    Generic,
-    assert_never,
-)
+from typing import Any, AsyncGenerator, AsyncIterable, Callable, Generic
 
 import agents
 from agents.models.chatcmpl_helpers import (
@@ -24,6 +17,7 @@ from typing_extensions import TypeVar
 
 from chatkit.errors import CustomStreamError, StreamError
 
+from ._compat import assert_never
 from .logger import logger
 from .store import AttachmentStore, Store, StoreItemType, default_generate_id
 from .types import (

--- a/tests/helpers/mock_widget.py
+++ b/tests/helpers/mock_widget.py
@@ -2,12 +2,13 @@ import os
 import re
 import uuid
 from datetime import datetime, timedelta
-from typing import Annotated, Any, AsyncIterator, Callable, Literal, assert_never
+from typing import Annotated, Any, AsyncIterator, Callable, Literal
 
 from agents import Agent, Runner
 from anyio import sleep
 from pydantic import BaseModel, Field, TypeAdapter
 
+from chatkit._compat import assert_never
 from chatkit.actions import Action, ActionConfig
 from chatkit.types import ThreadStreamEvent
 from chatkit.widgets import (


### PR DESCRIPTION
> [!NOTE] 
> This pull request is a fix to the #12 

This pull request introduces a new compatibility module to support Python versions earlier than 3.11, ensuring that features like `StrEnum` and `assert_never` are available across all supported environments. The main changes involve refactoring imports throughout the codebase to use these compatibility shims, improving cross-version compatibility and maintainability.

**Python compatibility improvements:**

* Added a new module `chatkit/_compat.py` that provides backports for `StrEnum` and `assert_never` for Python versions < 3.11. 
* Updated imports in `chatkit/errors.py`, `chatkit/agents.py`, `chatkit/server.py`, and `tests/helpers/mock_widget.py` to use `StrEnum` and `assert_never` from the new `_compat` module instead of directly from the standard library. 
* Removed direct imports of `assert_never` from the `typing` module in files where it is now provided by `_compat`. 

These changes ensure that the codebase remains functional and consistent across both older and newer Python versions.