### PR TITLE
fix - loosen overly strict ClientToolCall arguments type

### DIFF
--- a/chatkit/agents.py
+++ b/chatkit/agents.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from inspect import cleandoc
 from typing import (
     Annotated,
+    Any,
     AsyncGenerator,
     Awaitable,
     Generic,
@@ -84,7 +85,7 @@ class ClientToolCall(BaseModel):
     """
 
     name: str
-    arguments: dict[str, str]
+    arguments: dict[str, Any]
 
 
 class _QueueCompleteSentinel: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openai-chatkit"
-version = "1.0.1"
+version = "1.0.2"
 description = "A ChatKit backend SDK."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -819,7 +819,7 @@ wheels = [
 
 [[package]]
 name = "openai-chatkit"
-version = "1.0.1"
+version = "1.0.2"
 source = { virtual = "." }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION
ClientToolCall arguments can be any JSON serializable data