### PR TITLE
chore: run CI on merge groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   workflow_dispatch:
+  merge_group:
+    types: [checks_requested]
 
 env:
   UV_FROZEN: "1"


### PR DESCRIPTION
This will enable us to setup merge queue instead of requiring individual PRs to be up to date before merging