### PR TITLE
fix: allow payload on actions to be `undefined` by defaulting to `None`

### DIFF
--- a/chatkit/actions.py
+++ b/chatkit/actions.py
@@ -24,7 +24,7 @@ TPayload = TypeVar("TPayload")
 
 class Action(BaseModel, Generic[TType, TPayload]):
     type: TType = Field(default=TType, frozen=True)  # pyright: ignore
-    payload: TPayload
+    payload: TPayload = None # pyright: ignore - default to None to allow no-payload actions
 
     @classmethod
     def create(


### PR DESCRIPTION
Allow's client to send actions like so:

```ts
chatKit.sendCustomAction({ type: "test" })
```

Currently this crashes because the `Action` class expects `payload` to exist.