### PR TITLE
fix: Preserve metadata in _to_thread_response method

### DIFF
--- a/chatkit/server.py
+++ b/chatkit/server.py
@@ -726,4 +726,5 @@ class ChatKitServer(ABC, Generic[TContext]):
             created_at=thread.created_at,
             items=items,
             status=thread.status,
+            metadata=thread.metadata,
         )


### PR DESCRIPTION
## Problem

The `_to_thread_response` method is responsible for converting thread objects to response format, filtering out hidden context items, and returning a clean `Thread` object for client responses. However, it was missing the `metadata` field in the returned `Thread` object, causing metadata to be lost in all thread responses sent to clients.

### Impact

- `ThreadUpdatedEvent` would not include metadata set by responders
- Any other code path using `_to_thread_response` would lose metadata information
- This breaks the documented workflow for preserving context like `previous_response_id` for Agent SDK runs

## Solution

Added the `metadata` field to the `Thread` object construction in `_to_thread_response`:

```python
return Thread(
    id=thread.id,
    title=thread.title,
    created_at=thread.created_at,
    items=items,
    status=thread.status,
    metadata=thread.metadata,  # ← This line was missing
)
```

## Testing

Added a comprehensive test `test_metadata_preserved_in_thread_response` that:

1. Sets metadata in the responder function
2. Verifies that `ThreadCreatedEvent` has empty metadata (expected, as it's sent before responder runs)
3. **Verifies that `ThreadUpdatedEvent` correctly includes the metadata** (this would fail without the fix)
4. Confirms metadata is properly saved to the store
