### PR TITLE
Set python version to 3.10 and remove 3.11+ features

### DIFF
--- a/chatkit/agents.py
+++ b/chatkit/agents.py
@@ -11,7 +11,6 @@ from typing import (
     Generic,
     Sequence,
     TypeVar,
-    assert_never,
     cast,
 )
 
@@ -39,6 +38,7 @@ from openai.types.responses.response_output_text import (
     Annotation as ResponsesAnnotation,
 )
 from pydantic import BaseModel, ConfigDict, SkipValidation, TypeAdapter
+from typing_extensions import assert_never
 
 from .server import stream_widget
 from .store import Store, StoreItemType

--- a/chatkit/errors.py
+++ b/chatkit/errors.py
@@ -1,9 +1,9 @@
 from abc import ABC
-from enum import StrEnum
+from enum import Enum
 
 
 # Not a closed enum, new error codes can and will be added as needed
-class ErrorCode(StrEnum):
+class ErrorCode(str, Enum):
     STREAM_ERROR = "stream.error"
 
 

--- a/chatkit/server.py
+++ b/chatkit/server.py
@@ -9,7 +9,6 @@ from typing import (
     AsyncIterable,
     Callable,
     Generic,
-    assert_never,
 )
 
 import agents
@@ -20,7 +19,7 @@ from agents.models.openai_responses import (
     _HEADERS_OVERRIDE as responses_headers_override,
 )
 from pydantic import BaseModel, TypeAdapter
-from typing_extensions import TypeVar
+from typing_extensions import TypeVar, assert_never
 
 from chatkit.errors import CustomStreamError, StreamError
 

--- a/chatkit/widgets.py
+++ b/chatkit/widgets.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import (
     Annotated,
     Literal,
-    NotRequired,
 )
 
 from pydantic import (
@@ -13,7 +12,7 @@ from pydantic import (
     Field,
     model_serializer,
 )
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from chatkit.actions import ActionConfig
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ include = ["."]
 exclude = ["**/.venv", "**/.pytest_cache"]
 venvPath = "."
 venv = ".venv"
-pythonVersion = "3.11"
+pythonVersion = "3.10"
 typeCheckingMode = "standard"
 
 [tool.setuptools]

--- a/tests/helpers/mock_widget.py
+++ b/tests/helpers/mock_widget.py
@@ -2,11 +2,12 @@ import os
 import re
 import uuid
 from datetime import datetime, timedelta
-from typing import Annotated, Any, AsyncIterator, Callable, Literal, assert_never
+from typing import Annotated, Any, AsyncIterator, Callable, Literal
 
 from agents import Agent, Runner
 from anyio import sleep
 from pydantic import BaseModel, Field, TypeAdapter
+from typing_extensions import assert_never
 
 from chatkit.actions import Action, ActionConfig
 from chatkit.types import ThreadStreamEvent


### PR DESCRIPTION
Updates the Python project version to 3.10 and removes usages of features that were only introduced in 3.11:
* `assert_never` (imported from typing_extensions)
* `StrEnum` (replaced with Enum)
* `NotRequired` (imported from typing_extensions)

I tested by setting Python version to 3.10, then running make test.

Fixes #12.