### PR TITLE
Make IconName type change backwards compatible

### DIFF
--- a/chatkit/types.py
+++ b/chatkit/types.py
@@ -707,7 +707,8 @@ class CustomSummary(BaseModel):
     """Custom summary for a workflow."""
 
     title: str
-    icon: IconName | None = None
+    # IconName is the only supported type but we allow str for backwards compatibility
+    icon: IconName | str | None = None
 
 
 class DurationSummary(BaseModel):
@@ -735,7 +736,8 @@ class CustomTask(BaseTask):
 
     type: Literal["custom"] = "custom"
     title: str | None = None
-    icon: IconName | None = None
+    # IconName is the only supported type but we allow str for backwards compatibility
+    icon: IconName | str | None = None
     content: str | None = None
 
 
@@ -811,7 +813,8 @@ class EntitySource(SourceBase):
 
     type: Literal["entity"] = "entity"
     id: str
-    icon: IconName | None = None
+    # IconName is the only supported type but we allow str for backwards compatibility
+    icon: IconName | str | None = None
     preview: Literal["lazy"] | None = None
     data: dict[str, Any] = Field(default_factory=dict)
 


### PR DESCRIPTION
This backwards-incompatible change was part of 1.0.3: https://github.com/openai/chatkit-python/commit/c9f5f09d50d3fa3029f1576bc8750f0f01286b16

Updating this change to be backwards compatible with a new 1.0.4 patch.