### PR TITLE
Add ListView to the WidgetComponent Union

### DIFF
--- a/chatkit/widgets.py
+++ b/chatkit/widgets.py
@@ -1022,6 +1022,7 @@ WidgetComponent = Annotated[
     | Divider
     | Icon
     | Image
+    | ListView
     | ListViewItem
     | Button
     | Checkbox


### PR DESCRIPTION
Added ListView to the possible children of Card (WidgetComponent). This is in line with:

1. Docs here https://platform.openai.com/docs/guides/chatkit-widgets

2. Widgets generated by the Widget Builder (which create widgets like the following, where ListView is a child of Card

```<Card size="sm" padding={0}>
  <ListView>
    <ListViewItem
      onClickAction={{ type: "twistie.toggle" }}
      gap={2}
      align="center"
    >
      <Icon name={expanded ? "chevron-down" : "chevron-right"} />
      <Text value={expanded ? summary : summary} />
    </ListViewItem>
    {expanded && (
      <ListViewItem align="stretch">
        <Col padding={{ x: 4, y: 1 }} gap={2}>
          <Markdown value={content} />
        </Col>
      </ListViewItem>
    )}
  </ListView>
</Card>```