### PR TITLE
Fix: version header

### DIFF
--- a/chatkit/version.py
+++ b/chatkit/version.py
@@ -1,7 +1,7 @@
 import importlib.metadata
 
 try:
-    __version__ = importlib.metadata.version("chatkit")
+    __version__ = importlib.metadata.version("openai-chatkit")
 except importlib.metadata.PackageNotFoundError:
     # Fallback if running from source without being installed
     __version__ = "0.0.0"


### PR DESCRIPTION
This was not updated after the repo was made public, resulting in us sending 0.0.0 as version headers for ChatKit. Updating so that it references the official package name!

Tested locally:

<img width="723" height="61" alt="Screenshot 2025-11-06 at 12 54 42 PM" src="https://github.com/user-attachments/assets/d28a5dbf-bc4a-40e6-b539-95bc8a85b87c" />
