### PR TITLE
Constrain jinja2 dependency to <4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.4.0"
 description = "A ChatKit backend SDK."
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["pydantic", "uvicorn", "openai", "openai-agents>=0.3.2", "jinja2"]
+dependencies = ["pydantic", "uvicorn", "openai", "openai-agents>=0.3.2", "jinja2>=3.1,<4"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -852,7 +852,7 @@ lint = [
 
 [package.metadata]
 requires-dist = [
-    { name = "jinja2" },
+    { name = "jinja2", specifier = ">=3.1,<4" },
     { name = "openai" },
     { name = "openai-agents", specifier = ">=0.3.2" },
     { name = "pydantic" },


### PR DESCRIPTION
Fixing unbounded dependency before tagging v1.4.0