### PR TITLE
fix: start_workflow event never emits

### DIFF
--- a/chatkit/agents.py
+++ b/chatkit/agents.py
@@ -165,7 +165,7 @@ class AgentContext(BaseModel, Generic[TContext]):
             # Defer sending added event until we have tasks
             return
 
-            await self.stream(ThreadItemAddedEvent(item=self.workflow_item))
+        await self.stream(ThreadItemAddedEvent(item=self.workflow_item))
 
     async def update_workflow_task(self, task: Task, task_index: int) -> None:
         """Update an existing workflow task and stream the delta."""


### PR DESCRIPTION
  - Fix AgentContext.start_workflow so it emits the workflow ThreadItemAddedEvent (it previously short-circuited, so workflows never appeared).
  - Add regression test tests/test_agents.py::test_start_workflow_streams_added_task to verify a custom workflow with an initial task is streamed immediately.