### PR TITLE
fix: duplicated reasoning tasks

### DIFF
--- a/chatkit/server.py
+++ b/chatkit/server.py
@@ -697,7 +697,7 @@ class ChatKitServer(ABC, Generic[TContext]):
             with agents_sdk_user_agent_override():
                 async for event in stream():
                     if isinstance(event, ThreadItemAddedEvent):
-                        pending_items[event.item.id] = event.item
+                        pending_items[event.item.id] = event.item.model_copy(deep=True)
 
                     match event:
                         case ThreadItemDoneEvent():


### PR DESCRIPTION
- Prevent duplicated reasoning tasks by storing deep copies of newly added items in the streaming pending-items tracker, so _update_pending_items no longer mutates the responder’s original workflow item twice.
- Add regression test test_workflow_updates_not_applied_twice proving a responder that mutates a workflow before emitting updates yields only one reasoning task in both streamed and stored workflow items.