### PR TITLE
Add `label` and `interactive` fields to `EntitySource`

### DIFF
--- a/chatkit/types.py
+++ b/chatkit/types.py
@@ -860,6 +860,8 @@ class EntitySource(SourceBase):
     """Optional label shown with the icon in the default entity hover header
     when no preview callback is provided.
     """
+    interactive: bool = False
+    """Per-entity toggle to wire client callbacks and render this entity as interactive."""
     data: dict[str, Any] = Field(default_factory=dict)
     """Additional data for the entity source that is passed to client entity callbacks."""
 


### PR DESCRIPTION
* `label` will be displayed in the entity annotation hover view when no entity preview is available.
* `interactive` will control whether the entity source rendered as an inline annotation or in the source list is wired up to client callbacks for requesting previews / clicks.