### PR TITLE
[docs] mkdocs settings update

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,22 +71,11 @@ nav:
           - icons: api/chatkit/icons.md
   - Release process / changelog: release.md
   - ChatKit JS Docs: https://openai.github.io/chatkit-js/
+
 markdown_extensions:
-  - pymdownx.superfences:
-      custom_fences:
-        - name: mermaid
-          class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
-  - admonition
-  - attr_list
-  - md_in_html
-  - pymdownx.details
-  - pymdownx.highlight:
-      anchor_linenums: true
-      line_spans: __span
-      pygments_lang_class: true
-  - pymdownx.inlinehilite
-  - pymdownx.snippets
+  - fenced_code
+  - codehilite
+  - pymdownx.highlight
   - pymdownx.superfences
 
 extra_css:


### PR DESCRIPTION
For some reason the code snippets got all broken - simplifying the docs settings for a quick fix:

Before | After
--- | ---
<img width="752" height="631" alt="Screenshot 2025-12-17 at 3 22 48 PM" src="https://github.com/user-attachments/assets/c726e38f-cd7b-4cef-b333-b622c92027b1" /> |  <img width="737" height="700" alt="Screenshot 2025-12-17 at 3 23 00 PM" src="https://github.com/user-attachments/assets/2df68037-f1b8-43f8-85e6-a0f8edce7a92" />
