### PR TITLE
Add handling for sync actions

### DIFF
--- a/chatkit/actions.py
+++ b/chatkit/actions.py
@@ -16,6 +16,7 @@ class ActionConfig(BaseModel):
     payload: Any = None
     handler: Handler = DEFAULT_HANDLER
     loadingBehavior: LoadingBehavior = DEFAULT_LOADING_BEHAVIOR
+    streaming: bool = True
 
 
 TType = TypeVar("TType", bound=str)
@@ -32,6 +33,7 @@ class Action(BaseModel, Generic[TType, TPayload]):
         payload: TPayload,
         handler: Handler = DEFAULT_HANDLER,
         loading_behavior: LoadingBehavior = DEFAULT_LOADING_BEHAVIOR,
+        streaming: bool = True,
     ) -> ActionConfig:
         actionType: Any = None
         anno = cls.model_fields["type"].annotation
@@ -50,4 +52,5 @@ class Action(BaseModel, Generic[TType, TPayload]):
             payload=payload,
             handler=handler,
             loadingBehavior=loading_behavior,
+            streaming=streaming,
         )

--- a/chatkit/server.py
+++ b/chatkit/server.py
@@ -357,7 +357,7 @@ class ChatKitServer(ABC, Generic[TContext]):
             "See https://github.com/openai/chatkit-python/blob/main/docs/widgets.md#widget-actions"
         )
 
-    def sync_action(
+    async def sync_action(
         self,
         thread: ThreadMetadata,
         action: Action[str, Any],
@@ -707,7 +707,7 @@ class ChatKitServer(ABC, Generic[TContext]):
             raise ValueError("threads.sync_custom_action requires a widget sender item")
 
         return self._serialize(
-            self.sync_action(
+            await self.sync_action(
                 thread_metadata,
                 request.params.action,
                 item,

--- a/chatkit/types.py
+++ b/chatkit/types.py
@@ -115,6 +115,13 @@ class ThreadsCustomActionReq(BaseReq):
     params: ThreadCustomActionParams
 
 
+class ThreadsSyncCustomActionReq(BaseReq):
+    """Request to execute a custom action and return a single item update."""
+
+    type: Literal["threads.sync_custom_action"] = "threads.sync_custom_action"
+    params: ThreadCustomActionParams
+
+
 class ThreadCustomActionParams(BaseModel):
     """Parameters describing the custom action to execute."""
 
@@ -281,6 +288,7 @@ NonStreamingReq = (
     | ThreadsUpdateReq
     | ThreadsDeleteReq
     | InputTranscribeReq
+    | ThreadsSyncCustomActionReq
 )
 """Union of request types that yield immediate responses."""
 
@@ -537,6 +545,11 @@ ThreadItemUpdate = (
     | GeneratedImageUpdated
 )
 """Union of possible updates applied to thread items."""
+
+
+class SyncCustomActionResponse(BaseModel):
+    """Single thread item update returned by a sync custom action."""
+    updated_item: ThreadItem | None = None
 
 
 ### THREAD TYPES

--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -14,9 +14,14 @@ If you leave the handler unset, the action is delivered to `ChatKitServer.action
 
 When you set `handler: "client"`, the action flows into the client SDK’s `widgets.onAction` callback so you can do immediate UI work such as opening dialogs, navigating, or running local validation. Client handlers can still forward a follow-up action to the server with `chatkit.sendCustomAction()` after local logic finishes. The server thread stays unchanged unless you explicitly send that follow-up action or a message.
 
+### Sync server-handled actions
+
+Normally, widget actions are blocked while a thread is streaming a response. This prevents race conditions, but it can be limiting when a widget action is only going to update itself or trigger side effects outside the thread. To get around this limitation, set `streaming: "false"`, which delivers the action to `ChatKitServer.sync_action(thread, action, sender, context)`. Use this handler to run any side effects and update the widget's UI as needed.
+
 ## Client-sent actions using the chatkit.sendCustomAction() command
 
 Your client integration can also initiate actions directly with `chatkit.sendCustomAction(action, itemId?)`, optionally namespaced to a specific widget item. The server receives these in `ChatKitServer.action` just like a widget-triggered action and can stream widgets, messages, or client effects in response. This pattern is useful when a flow starts outside a widget—or after a client-handled action—but you still want the server to persist results or involve the model.
 
 ## Related guides
+
 - [Build interactive responses with widgets](../guides/build-interactive-responses-with-widgets.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openai-chatkit"
-version = "1.6.1"
+version = "1.6.2"
 description = "A ChatKit backend SDK."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_chatkit_server.py
+++ b/tests/test_chatkit_server.py
@@ -194,7 +194,7 @@ def make_server(
                 raise ValueError("action_callback not wired up")
             return action_callback(thread, action, sender, context)
 
-        def sync_action(
+        async def sync_action(
             self,
             thread: ThreadMetadata,
             action: Action[str, Any],

--- a/uv.lock
+++ b/uv.lock
@@ -819,7 +819,7 @@ wheels = [
 
 [[package]]
 name = "openai-chatkit"
-version = "1.6.1"
+version = "1.6.2"
 source = { virtual = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Adds handling for sync actions.

Normally, widget actions are blocked while a thread is streaming a response. This prevents race conditions, but it can be limiting when a widget action is only going to update itself or trigger side effects outside the thread. To get around this limitation, we're adding `ChatKitServer.sync_action` where you can run any side effects and update the widget's UI as needed. To route an action to this handler, add `streaming: false` to the action. If a widget action includes `streaming: false` it won't be blocked during streaming. 