### PR TITLE
docs: add backend verification note for backend setup

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -65,6 +65,10 @@ Install the ChatKit Python package and expose a single `/chatkit` endpoint that 
 ```sh
 pip install openai-chatkit
 ```
+or if you are using uv
+```sh
+uv add openai-chatkit
+```
 
 Create `main.py` with a minimal server that is hard-coded to always reply “Hello, world!”—you'll replace this with an actual call to a model in [Respond to a user message](guides/respond-to-user-message.md).
 
@@ -218,6 +222,19 @@ This store implements only the methods required for basic chat while the server 
 
 For production, replace this with a database-backed store (for example, Postgres or MySQL) so threads and items persist across restarts.
 
+
+## Verify your backend
+You can confirm that your server is handling requests correctly by sending a test message directly with curl. With the server running, execute: 
+```sh
+curl -X POST http://localhost:8000/chatkit \
+  -H "Content-Type: application/json" \
+  -d '{"type":"threads.create","params":{"input":{"content":[{"type":"input_text","text":"Hi there!"}],"quoted_text":"","attachments":[],"inference_options":{}}}}'
+```
+
+If your server is set up correctly with the hardcoded "Hello, world!" reply from Run your ChatKit server, you should see a streaming response similar to this:
+```sh
+data: {"type":"thread.item.done","item":{"id":"msg_1771791100.445294","thread_id":"thr_63b87b34","created_at":"2026-02-22T20:11:40.445303Z","type":"assistant_message","content":[{"annotations":[],"text":"Hello, world!","type":"output_text"}]}}
+```
 
 ## Generate model responses
 


### PR DESCRIPTION
### Backend verification note

This adds a `curl` test to verify that the ChatKit server and its memory store are correctly configured before working on the frontend.

I ran into this while trying to confirm my backend was functioning prior to UI development. The documentation does not clearly specify what payload should be sent to `/chatkit`. Many AI suggestions recommended sending:

```
curl -X POST http://localhost:8000/chatkit \
  -H "Content-Type: application/json" \
  -d '{}'
```

However, this results in an **Internal Server Error**, which can misleadingly make it seem like the server or installation is broken.

I determined the required parameters by using one of the ChatKit customer-service examples and logging/printing the actual request payload. Including this verification step should help developers quickly confirm that their backend and memory store are properly set up and avoid unnecessary debugging.

I've also added a chore where the document gives the developer the option to choose uv.