### PR TITLE
Add `allowed_image_domains` to client-visible `ThreadMetadata`

### DIFF
--- a/chatkit/server.py
+++ b/chatkit/server.py
@@ -977,4 +977,5 @@ class ChatKitServer(ABC, Generic[TContext]):
             created_at=thread.created_at,
             items=items,
             status=thread.status,
+            allowed_image_domains=thread.allowed_image_domains,
         )

--- a/chatkit/types.py
+++ b/chatkit/types.py
@@ -562,7 +562,7 @@ class ThreadMetadata(BaseModel):
     id: str
     created_at: datetime
     status: ThreadStatus = Field(default_factory=lambda: ActiveStatus())
-    # TODO - make not client rendered
+    allowed_image_domains: list[str] | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openai-chatkit"
-version = "1.6.2"
+version = "1.6.3"
 description = "A ChatKit backend SDK."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_chatkit_server.py
+++ b/tests/test_chatkit_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import json
 import sqlite3
 from contextlib import contextmanager
 from datetime import datetime
@@ -637,6 +638,78 @@ async def test_saves_thread_locked_fields():
         assert loaded.status == LockedStatus(reason="Because")
         assert events[-1].type == "thread.updated"
         assert events[-1].thread.status == LockedStatus(reason="Because")
+
+
+async def test_saves_allowed_image_domains_and_streams_thread_updated():
+    async def responder(
+        thread: ThreadMetadata, input: UserMessageItem | None, context: Any
+    ) -> AsyncIterator[ThreadStreamEvent]:
+        thread.allowed_image_domains = ["example.com", "images.example.com"]
+        return
+        yield
+
+    with make_server(responder) as server:
+        events = await server.process_streaming(
+            ThreadsCreateReq(
+                params=ThreadCreateParams(
+                    input=UserMessageInput(
+                        content=[UserMessageTextContent(text="Hello, world!")],
+                        attachments=[],
+                        inference_options=InferenceOptions(),
+                    )
+                )
+            )
+        )
+        thread = next(
+            event.thread for event in events if event.type == "thread.created"
+        )
+        loaded = await server.store.load_thread(thread.id, DEFAULT_CONTEXT)
+        assert loaded.allowed_image_domains == ["example.com", "images.example.com"]
+        assert events[-1].type == "thread.updated"
+        assert events[-1].thread.allowed_image_domains == [
+            "example.com",
+            "images.example.com",
+        ]
+
+
+async def test_omits_unset_allowed_image_domains_in_created_and_updated_json_events():
+    async def responder(
+        thread: ThreadMetadata, input: UserMessageItem | None, context: Any
+    ) -> AsyncIterator[ThreadStreamEvent]:
+        thread.title = "Updated title"
+        return
+        yield
+
+    with make_server(responder) as server:
+        stream = await server.process(
+            ThreadsCreateReq(
+                params=ThreadCreateParams(
+                    input=UserMessageInput(
+                        content=[UserMessageTextContent(text="Hello, world!")],
+                        attachments=[],
+                        inference_options=InferenceOptions(),
+                    )
+                )
+            ).model_dump_json(),
+            DEFAULT_CONTEXT,
+        )
+        assert isinstance(stream, StreamingResult)
+
+        thread_created_event: dict[str, Any] | None = None
+        thread_updated_event: dict[str, Any] | None = None
+        async for raw in stream.json_events:
+            event = json.loads(raw.split(b"data: ")[1])
+            if event["type"] == "thread.created":
+                thread_created_event = event
+            if event["type"] == "thread.updated":
+                thread_updated_event = event
+
+        assert thread_created_event is not None
+        assert "allowed_image_domains" not in thread_created_event["thread"]
+
+        assert thread_updated_event is not None
+        assert thread_updated_event["thread"]["title"] == "Updated title"
+        assert "allowed_image_domains" not in thread_updated_event["thread"]
 
 
 async def test_emits_thread_updated_mid_stream_and_persists():

--- a/uv.lock
+++ b/uv.lock
@@ -819,7 +819,7 @@ wheels = [
 
 [[package]]
 name = "openai-chatkit"
-version = "1.6.2"
+version = "1.6.3"
 source = { virtual = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
If provided, this will restrict the images that are allowed to be rendered in assistant messages for the thread.


Tested locally:

No `allowed_image_domains` by default | Streamed back as thread.updated event when added in respond() | Excluded when only the title is added
--- | --- | ---
<img width="1486" height="838" alt="Screenshot 2026-03-04 at 10 38 43 AM" src="https://github.com/user-attachments/assets/0484b762-62ae-4de8-bd90-f5590d63332e" /> |  <img width="1506" height="830" alt="Screenshot 2026-03-04 at 10 50 36 AM" src="https://github.com/user-attachments/assets/03cf9c78-d1c8-47de-9a8a-67ced59d27d5" /> |  <img width="1508" height="790" alt="Screenshot 2026-03-04 at 10 51 56 AM" src="https://github.com/user-attachments/assets/4ef1eaf1-1cd6-479f-8f4e-95276627a4ce" />


Saved to thread and retrieved on load:

<img width="300" alt="Screenshot 2026-03-04 at 10 54 17 AM" src="https://github.com/user-attachments/assets/a49f4e02-a2da-4e47-977c-cbb7e567d3b6" />

